### PR TITLE
Fix for hud disappear

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
-<modDesc descVersion="64">
+<modDesc descVersion="66">
     <author>Wopster</author>
-    <version>2.0.0.0</version>
+    <version>2.0.0.1</version>
     <title>
         <en>ProSeed</en>
     </title>

--- a/src/hud/elements/HUDMovableElement.lua
+++ b/src/hud/elements/HUDMovableElement.lua
@@ -26,23 +26,28 @@ function HUDMovableElement:loadFromXMLFile(xmlFile, key)
     local y = getXMLFloat(xmlFile, key .. ".position#y")
 
     if x ~= nil and y ~= nil then
-        x = MathUtil.clamp(x, 0, 1)
-        y = MathUtil.clamp(y, 0, 1)
+        x = MathUtil.clamp(x, 0, 0.8556) -- max coursor posX: 0.85562500490031
+        y = MathUtil.clamp(y, 0, 0.8366) -- max coursor posY: 0.83666667099352
+        local correction = 0.2466 
+        local add_corr = 0.0236 -- error 51px (+0.02361) at 4K
 
-        local height = self:getHeight()
-        local _, parentY = self.parent:getPosition()
-        local _, marginHeight = self.parent:scalePixelToScreenVector(InteractiveHUD.SIZE.BOX_MARGIN)
+        -- local height = self:getHeight()
+        -- local _, parentY = self.parent:getPosition()
+        -- local _, marginHeight = self.parent:scalePixelToScreenVector(InteractiveHUD.SIZE.BOX_MARGIN)
 
         --Do height correction based on the parent position.
-        self:setPosition(x, y + (height * 0.5) + parentY - marginHeight)
+        -- self:setPosition(x, y + (height * 0.5) + parentY - marginHeight)
+        
+        -- self:setPosition(x, y - correction - add_corr) -- not good for FHD
+        self:setPosition(x, y - correction)
     end
 end
 
 function HUDMovableElement:saveToXMLFile(xmlFile, key)
     local x, y = self:getPosition()
     if x ~= nil and y ~= nil then
-        setXMLFloat(xmlFile, key .. ".position#x", MathUtil.clamp(x, 0, 1))
-        setXMLFloat(xmlFile, key .. ".position#y", MathUtil.clamp(y, 0, 1))
+        setXMLFloat(xmlFile, key .. ".position#x", MathUtil.clamp(x, 0, 0.8556))
+        setXMLFloat(xmlFile, key .. ".position#y", MathUtil.clamp(y, 0, 0.8366))
     end
 end
 
@@ -105,6 +110,7 @@ function HUDMovableElement:setPositionByMousePosition(mouseX, mouseY)
         end
 
         self:setPosition(newX, newY)
+        -- log("New pos", newX, newY) -- DEV
         self.currentMouseX = mouseX
         self.currentMouseY = mouseY
     end

--- a/src/hud/elements/HUDMovableElement.lua
+++ b/src/hud/elements/HUDMovableElement.lua
@@ -26,8 +26,8 @@ function HUDMovableElement:loadFromXMLFile(xmlFile, key)
     local y = getXMLFloat(xmlFile, key .. ".position#y")
 
     if x ~= nil and y ~= nil then
-        x = MathUtil.clamp(x, 0, 0.8556) -- max coursor posX: 0.85562500490031
-        y = MathUtil.clamp(y, 0, 0.8366) -- max coursor posY: 0.83666667099352
+        x = MathUtil.clamp(x, 0, 0.8556) -- max cursor posX: 0.85562500490031
+        y = MathUtil.clamp(y, 0, 0.8366) -- max cursor posY: 0.83666667099352
         local correction = 0.2466 
         local add_corr = 0.0236 -- error 51px (+0.02361) at 4K
 


### PR DESCRIPTION
After a few tests, it turned out that the position of the HUD is completely different from the cursor position and it is impossible to save the data with the coordinates 1x1. So I set the maximum ranges and additionally added an error for the Y position. Checked on FHD, 2K and 4K resolutions and only at 4K is the Y position error visible (after loading `+0.02361` [51px]), but after adjusting for this error on the FHD, the HUD is off the top edge.

4K, set and saved:
https://cdn.discordapp.com/attachments/939967467931975782/987483978296623174/2022-06-17_18_27_34-Farming_Simulator_22.png
loaded:
https://cdn.discordapp.com/attachments/939967467931975782/987483979592630312/2022-06-17_18_28_29-Farming_Simulator_22.png